### PR TITLE
 buildspec.yml example with few nice features

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+ENV HELLO WORLD

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # codebuild
-This is codebuild test repo
+
+![Build Status](https://codebuild.eu-west-3.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoia1VnMTBNS3llWFZMUFhuZWhocDVYdmpZTmVGNjJGeUdkSUFFUkExSmZzYmt1MFJEL1RGelBCU3BMcjhEeUxZVk1naUpoUmhnN2F0ay9NN3dOMDhjTDNrPSIsIml2UGFyYW1ldGVyU3BlYyI6Imlxblp2d1VqK2RvNHljaFYiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=master)
+
+This is example of codebuild
+for build/push docker image into ECR with corresponding REPO name
+IMAGE_TAG must use git tag

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,27 @@
+version: 0.2
+
+env:
+  shell: bash
+
+phases:
+  install:
+    commands:
+      - echo running an install
+      - export REPO_NAME=$(basename ${CODEBUILD_SOURCE_REPO_URL/\.git})
+      - export IMAGE_REPO_NAME=$(aws ecr describe-repositories --repository-names ${REPO_NAME} --output text --query 'repositories[*].[repositoryUri]')
+      - export IMAGE_TAG='latest'
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $IMAGE_REPO_NAME
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Building the Docker image...
+      - docker build -t $IMAGE_REPO_NAME:$IMAGE_TAG .
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker image...
+      - docker push $IMAGE_REPO_NAME:$IMAGE_TAG
+      - echo Job completed on `date`


### PR DESCRIPTION
Almost empty Dockerfile
enabled bash at buildspec.yaml

README.md with nice badge

And last but not least"
buildspec.yml with autodiscovery for build and push new docker image
into AWS ECR

For now it use latest tag, but git tag for docker image tag will be
added later